### PR TITLE
added language flag

### DIFF
--- a/google_ngram_downloader/__main__.py
+++ b/google_ngram_downloader/__main__.py
@@ -19,12 +19,13 @@ def download(
     ngram_len=('n', 1, 'The length of ngrams to be downloaded.'),
     output=('o', 'downloads/google_ngrams/{ngram_len}', 'The destination folder for downloaded files.'),
     verbose=('v', False, 'Be verbose.'),
+    lang=('l', "eng", 'Language: eng'),
 ):
     """Download The Google Books Ngram Viewer dataset version 20120701."""
     output = local(output.format(ngram_len=ngram_len))
     output.ensure_dir()
 
-    for fname, url, request in iter_google_store(ngram_len, verbose=verbose):
+    for fname, url, request in iter_google_store(ngram_len, verbose=verbose,lang=lang):
         with output.join(fname).open('wb') as f:
             for num, chunk in enumerate(request.iter_content(1024)):
                 if verbose and not divmod(num, 1024)[1]:
@@ -39,14 +40,15 @@ def cooccurrence(
     output=('o', 'downloads/google_ngrams/{ngram_len}_cooccurrence_matrix/', 'The destination folder for downloaded files.'),
     verbose=('v', False, 'Be verbose.'),
     rewrite=('r', False, 'Always rewrite existing files.'),
-    records_in_file=('', 10 ** 9, 'The number of records to be read from the Google store to store in a .json.gz file.')
+    records_in_file=('', 10 ** 9, 'The number of records to be read from the Google store to store in a .json.gz file.'),
+    lang=('l', "eng", 'Language: eng'),
 ):
     """Build a cooccurrence matrix based on ngram data."""
     assert ngram_len > 1
     output_dir = local(output.format(ngram_len=ngram_len))
     output_dir.ensure_dir()
 
-    for fname, _, all_records in readline_google_store(ngram_len, verbose=verbose):
+    for fname, _, all_records in readline_google_store(ngram_len, lang=lang,  verbose=verbose):
         postfix = 0
         while (True):
             records = islice(all_records, records_in_file)
@@ -83,13 +85,14 @@ def cooccurrence(
 @command()
 def readline(
     ngram_len=('n', 2, 'The length of ngrams to be downloaded.'),
+    lang=('l', "eng", 'Language: eng'),
 ):
     """Print the raw content."""
 
     # Always write utf8
     sys.stdout = codecs.getwriter('utf8')(sys.stdout)
 
-    for _, _, records in readline_google_store(ngram_len):
+    for _, _, records in readline_google_store(ngram_len, lang=lang):
         for record in records:
             print(record)
             print('{ngram}\t{year}\t{match_count}\t{volume_count}'.format(**record._asdict()))

--- a/google_ngram_downloader/util.py
+++ b/google_ngram_downloader/util.py
@@ -10,13 +10,13 @@ import requests
 URL_TEMPLATE = 'http://storage.googleapis.com/books/ngrams/books/{}'
 # URL_TEMPLATE = 'http://localhost:8001/{}'
 
-FILE_TEMPLATE = 'googlebooks-eng-all-{ngram_len}gram-{version}-{index}.gz'
+FILE_TEMPLATE = 'googlebooks-{lang}-all-{ngram_len}gram-{version}-{index}.gz'
 
 
 Record = collections.namedtuple('Record', 'ngram year match_count volume_count')
 
 
-def readline_google_store(ngram_len, chunk_size=1024 ** 2, verbose=False):
+def readline_google_store(ngram_len, lang='eng', chunk_size=1024 ** 2, verbose=False):
     """Iterate over the data in the Google ngram collectioin.
 
         :param int ngram_len: the length of ngrams to be streamed.
@@ -28,7 +28,7 @@ def readline_google_store(ngram_len, chunk_size=1024 ** 2, verbose=False):
 
     """
 
-    for fname, url, request in iter_google_store(ngram_len, verbose=verbose):
+    for fname, url, request in iter_google_store(ngram_len, verbose=verbose,lang=lang):
         dec = zlib.decompressobj(32 + zlib.MAX_WBITS)
 
         def lines():
@@ -88,13 +88,14 @@ def count_coccurrence(records, index):
     return counter
 
 
-def iter_google_store(ngram_len, verbose=False):
+def iter_google_store(ngram_len, lang="eng", verbose=False):
     """Iterate over the collection files stored at Google."""
     version = '20120701'
     session = requests.Session()
 
     for index in get_indices(ngram_len):
         fname = FILE_TEMPLATE.format(
+            lang=lang,
             ngram_len=ngram_len,
             version=version,
             index=index,


### PR DESCRIPTION
Added a "-l" flag to allow for downloading other languages then US English ("eng").  I only tested it for download command, sorry.

ex: 
google-ngram-downloader download -v -o /tmp/tay/ -n1 -lchi-sim
google-ngram-downloader download -v -o /tmp/tay/ -n1 -leng-gb
